### PR TITLE
Summarizer model

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ This project creates an asynchronous RESTful API built with Python, FastAPI, and
     -d '{"url": "https://realpython.com/pointers-in-python/"}'
     ```
 
+    The payload also supports two additional optional parameters:
+    - `summarizer_specifier`: Specifies the summarization algorithm. Supported values are `lsa`, `lex_rank`, `text_rank`, and `edmundson`. If not provided, the default is `lsa`.
+    - `sentence_count`: Specifies the number of sentences in the generated summary, with a range of 5 to 30. If not provided, the default is 10.
+
+    Example request with all parameters:
+
+    ```bash
+    curl -X POST "https://text-summarizer-d918be4fb9c8.herokuapp.com/summaries/" \
+    -H "Content-Type: application/json" \
+    -d '{"url": "https://realpython.com/pointers-in-python/", "summarizer_specifier": "lex_rank", "sentence_count": 15}'
+    ```
+
+    For more information on the supported summarization algorithms, see the [sumy documentation](https://github.com/miso-belica/sumy/blob/main/docs/summarizators.md).
+
 - **Get a summary:** `GET /summaries/{id}/`
 
   ```bash
@@ -56,7 +70,7 @@ This project creates an asynchronous RESTful API built with Python, FastAPI, and
   ```bash
   curl -X PUT "https://text-summarizer-d918be4fb9c8.herokuapp.com/summaries/{id}/" \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://realpython.com/pointers-in-python/", "summary": "Updated summary text"}'
+  -d '{"url": "https://realpython.com/pointers-in-python/", "update_summary": "Updated summary text"}'
   ```
 
 - **Delete a summary:** `DELETE /summaries/{id}/`

--- a/project/app/api/crud.py
+++ b/project/app/api/crud.py
@@ -12,7 +12,8 @@ async def post(payload: SummaryPayloadSchema) -> int:
     Parameters
     ----------
     payload : SummaryPayloadSchema
-        The payload containing a valid url required to create the new summary.
+        The payload containing a valid url, the string name of the algorithm to use, and optionally
+        an integer representing the number of sentences to include in the output.
 
     Returns
     -------
@@ -96,7 +97,9 @@ async def put(id: int, payload: SummaryUpdatePayloadSchema) -> Union[Dict, None]
         The updated summary as a dictionary if successful, or None if no summary was found for the given ID.
     """
     # The return object is an instance of UpdateQuery or None depending on if filter finds the given ID
-    summary = await TextSummary.filter(id=id).update(url=payload.url, summary=payload.summary)
+    summary = await TextSummary.filter(id=id).update(
+        url=payload.url, summary=payload.update_summary
+    )
     if summary:
         # Update and return the updated summary schema {"id": ..., "url": ..., "summary": ...}
         updated_summary_schema = await TextSummary.filter(id=id).first().values()

--- a/project/app/summarizer.py
+++ b/project/app/summarizer.py
@@ -2,27 +2,35 @@ import nltk
 from sumy.nlp.stemmers import Stemmer
 from sumy.nlp.tokenizers import Tokenizer
 from sumy.parsers.html import HtmlParser
-from sumy.summarizers.lsa import LsaSummarizer as Summarizer
+from sumy.summarizers.edmundson import EdmundsonSummarizer
+from sumy.summarizers.lex_rank import LexRankSummarizer
+from sumy.summarizers.lsa import LsaSummarizer
+from sumy.summarizers.text_rank import TextRankSummarizer
 from sumy.utils import get_stop_words
 
+from app.models.pydantic import SummarizerSpecifier
 from app.models.tortoise import TextSummary
 
 LANGUAGE = "english"
-SUMMARY_SENTENCE_COUNT = 10
+stop_words = get_stop_words(LANGUAGE)
+
+summarizers = {
+    "lsa": LsaSummarizer,
+    "lex_rank": LexRankSummarizer,
+    "text_rank": TextRankSummarizer,
+    "edmundson": EdmundsonSummarizer,
+}
 
 
-async def generate_summary(id: int, url: str) -> None:
+async def generate_summary(
+    id: int, url: str, summarizer_specifier: SummarizerSpecifier, sentence_count: int
+) -> None:
     """
     Create a summary of an article from a given URL using the `sumy` package. The summarization methods available include:
 
-    - **Random**: A baseline for comparison, not used in real-world applications.
-    - **Luhn**: Heuristic, based on significant words (non-stop-words with high frequency).
     - **Edmundson**: Enhanced Luhn method with pragmatic words and positional heuristics.
     - **LSA (Latent Semantic Analysis)**: Algebraic, language-independent, identifies synonyms.
     - **LexRank/TextRank**: Graph-based, finds connections between sentences.
-    - **SumBasic**: Baseline, compares against other algorithms.
-    - **KL-Sum**: Greedy, reduces KL Divergence between sentences and the document.
-    - **Reduction**: Graph-based, computes sentence salience through edge weights.
 
     Parameters
     ----------
@@ -30,6 +38,10 @@ async def generate_summary(id: int, url: str) -> None:
         The generated id for this summary record.
     url : str
         The URL of the article to summarize.
+    summarizer_specifier : SummarizerSpecifier
+        The summarization algorithm to use.
+    sentence_count : int
+        The number of sentences in the summary.
 
     Returns
     -------
@@ -42,17 +54,24 @@ async def generate_summary(id: int, url: str) -> None:
         nltk.download("punkt_tab")
 
     try:
+        # Note that this is an enum instance
+        summarizer_name = summarizer_specifier.value
         # Parse content from the provided URL
         parser = HtmlParser.from_url(url, Tokenizer(LANGUAGE))
 
         # Apply stemmer and stop words processing
         stemmer = Stemmer(LANGUAGE)
-        summarizer = Summarizer(stemmer)
-        summarizer.stop_words = get_stop_words(LANGUAGE)
+        summarizer = summarizers[summarizer_name](stemmer)
+        if summarizer_name == "edmundson":
+            summarizer.bonus_words = parser.significant_words
+            summarizer.stigma_words = parser.stigma_words
+            summarizer.null_words = stop_words
+        elif summarizer_name in ["lsa", "lex_rank", "text_rank"]:
+            summarizer.stop_words = stop_words
 
         # Generate the summary
         summary = "\n".join(
-            sentence._text for sentence in summarizer(parser.document, SUMMARY_SENTENCE_COUNT)
+            sentence._text for sentence in summarizer(parser.document, sentence_count)
         )
 
         # Check if the summary is empty and update with a message if necessary


### PR DESCRIPTION
* Support additional summarization algorithms from `sumy`, including lsa (default), edmundson, text rank and lex rank
* Add options for the post `/summaries/` endpoint--- `summarizer_specifier` and `sentence_count` (defaults to 10)
* Update and fix all tests